### PR TITLE
Fixed countNotRead() method

### DIFF
--- a/src/Fenos/Notifynder/Notifications/Repositories/NotificationRepository.php
+++ b/src/Fenos/Notifynder/Notifications/Repositories/NotificationRepository.php
@@ -269,6 +269,6 @@ class NotificationRepository {
     {
         return $this->notification->wherePolymorphic('to_id','to_type',$to_id,$this->entity)
             ->withNotRead()
-            ->count()
+            ->count();
     }
 } 


### PR DESCRIPTION
Use count() to return a integer
