### PR TITLE
add/updateCategory back port and fix for Notifynder 2.x

### DIFF
--- a/src/Fenos/Notifynder/Notifynder.php
+++ b/src/Fenos/Notifynder/Notifynder.php
@@ -120,6 +120,29 @@ class Notifynder implements NotifynderInterface {
 
         return $this;
     }
+    
+    /**
+     * Add a category
+     *
+     * @param $name
+     * @param $text
+     * @return static
+     */
+    public function addCategory($name,$text)
+    {
+        return $this->notifynderCategory->add(compact('name','text'));
+    }
+    /**
+     * Update a category
+     *
+     * @param array $updates
+     * @param       $id
+     * @return mixed
+     */
+    public function updateCategory(array $updates, $id)
+    {
+        return $this->notifynderCategory->update($updates,$id);
+    }
 
     /**
      * Send notifications

--- a/src/Fenos/Notifynder/NotifynderInterface.php
+++ b/src/Fenos/Notifynder/NotifynderInterface.php
@@ -30,6 +30,24 @@ interface NotifynderInterface {
      * @return $this
      */
     public function entity($name);
+    
+    /**
+     * Add a category
+     *
+     * @param $name
+     * @param $text
+     * @return static
+     */
+    public function addCategory($name, $text);
+    
+    /**
+     * Update a category
+     *
+     * @param array $updates
+     * @param       $id
+     * @return mixed
+     */
+    public function updateCategory(array $updates, $id);
 
     /**
      * Send notifications


### PR DESCRIPTION
This respond to issue #22 and #24, back porting method from current 3.0 for user of Notifynder 2.0