### PR TITLE
Fix #27 - parse method should not convert an Eloquent Object to an array...

### DIFF
--- a/src/Fenos/Notifynder/Models/Collection/NotifynderCollection.php
+++ b/src/Fenos/Notifynder/Models/Collection/NotifynderCollection.php
@@ -122,7 +122,7 @@ class NotifynderCollection extends Collection {
 
         foreach($this->items as $key => $item)
         {
-            $notifications[$key] = $item->toArray();
+            $notifications[$key] = $item;
             $notifications[$key]['body']['text'] = $parse->parse($item,$item->extra);
         }
 


### PR DESCRIPTION
This actually fix an issue which make us unable to call any attributes/proprieties though the Eloquent Object, relation with issue #27