### PR TITLE
Updated the down method of the "alter category name to unique" migration…

### DIFF
--- a/src/migrations/2015_06_07_211555_alter_category_name_to_unique.php
+++ b/src/migrations/2015_06_07_211555_alter_category_name_to_unique.php
@@ -25,7 +25,7 @@ class AlterCategoryNameToUnique extends Migration
     public function down()
     {
         Schema::table('notification_categories', function ($table) {
-            $table->dropUnique('name');
+            $table->dropUnique('notification_categories_name_unique');
         });
     }
 }


### PR DESCRIPTION
It now references the correct name of the unique key. (Which is weirdly non-intuitive!)