### PR TITLE
Fix #44 Pagination Issues

### DIFF
--- a/spec/Fenos/Notifynder/Notifications/NotificationManagerSpec.php
+++ b/spec/Fenos/Notifynder/Notifications/NotificationManagerSpec.php
@@ -127,7 +127,7 @@ class NotificationManagerSpec extends ObjectBehavior
     {
         $entity_id = 1;
         $limit = 10;
-        $paginate = false;
+        $paginate = null;
 
         $notificationRepo->getNotRead($entity_id,null,$limit,$paginate,'desc')->shouldBeCalled()
                     ->willReturn($collection);
@@ -142,7 +142,7 @@ class NotificationManagerSpec extends ObjectBehavior
     {
         $entity_id = 1;
         $limit = 10;
-        $paginate = false;
+        $paginate = null;
 
         $notificationRepo->getAll($entity_id,null,$limit,$paginate,'desc')->shouldBeCalled()
             ->willReturn($collection);

--- a/src/Notifynder/Notifable.php
+++ b/src/Notifynder/Notifable.php
@@ -89,7 +89,7 @@ trait Notifable
      * @param  string $order
      * @return mixed
      */
-    public function getNotificationsNotRead($limit = null, $paginate = false, $order = 'desc')
+    public function getNotificationsNotRead($limit = null, $paginate = null, $order = 'desc')
     {
         return $this->notifynderInstance()->entity(
             $this->getMorphClass()
@@ -104,7 +104,7 @@ trait Notifable
      * @param  string $order
      * @return mixed
      */
-    public function getNotifications($limit = null, $paginate = false, $order = 'desc')
+    public function getNotifications($limit = null, $paginate = null, $order = 'desc')
     {
         return $this->notifynderInstance()->entity(
             $this->getMorphClass()

--- a/src/Notifynder/Notifable.php
+++ b/src/Notifynder/Notifable.php
@@ -85,7 +85,7 @@ trait Notifable
      * Get Not Read
      *
      * @param  null   $limit
-     * @param  bool   $paginate
+     * @param  int|null   $paginate
      * @param  string $order
      * @return mixed
      */
@@ -100,7 +100,7 @@ trait Notifable
      * Get all notifications
      *
      * @param  null   $limit
-     * @param  bool   $paginate
+     * @param  int|null   $paginate
      * @param  string $order
      * @return mixed
      */

--- a/src/Notifynder/Notifications/NotificationManager.php
+++ b/src/Notifynder/Notifications/NotificationManager.php
@@ -165,21 +165,20 @@ class NotificationManager implements NotifynderNotification
      *
      * @param         $to_id
      * @param         $limit
-     * @param         $paginate
+     * @param  int|null $paginate
      * @param  string $orderDate
      * @return mixed
      */
-    public function getNotRead($to_id, $limit = null, $paginate = false, $orderDate = 'desc')
+    public function getNotRead($to_id, $limit = null, $paginate = null, $orderDate = 'desc')
     {
         $notifications = $this->notifynderRepo->getNotRead(
             $to_id, $this->entity,
             $limit, $paginate, $orderDate
         );
 
-        if ($paginate) {
-            return (new Paginator(
-                $notifications->parse()->toArray(), $limit
-            ))->toArray();
+        if(is_int(intval($paginate)) && !is_null($paginate))
+        {
+            return (new Paginator($notifications->parse()->toArray(), $limit, $paginate))->toArray();
         }
 
         return $notifications->parse();
@@ -190,21 +189,20 @@ class NotificationManager implements NotifynderNotification
      *
      * @param         $to_id
      * @param         $limit
-     * @param         $paginate
+     * @param  int|null $paginate
      * @param  string $orderDate
      * @return mixed
      */
-    public function getAll($to_id, $limit = null, $paginate = false, $orderDate = 'desc')
+    public function getAll($to_id, $limit = null, $paginate = null, $orderDate = 'desc')
     {
         $notifications = $this->notifynderRepo->getAll(
             $to_id, $this->entity,
             $limit, $paginate, $orderDate
         );
 
-        if ($paginate) {
-            return (new Paginator(
-                $notifications->parse()->toArray(), $limit
-            ))->toArray();
+        if(is_int(intval($paginate)) && !is_null($paginate))
+        {
+            return (new Paginator($notifications->parse()->toArray(), $limit, $paginate))->toArray();
         }
 
         return $notifications->parse();

--- a/src/Notifynder/Notifications/NotificationRepository.php
+++ b/src/Notifynder/Notifications/NotificationRepository.php
@@ -213,12 +213,12 @@ class NotificationRepository implements NotificationDB, StoreNotification
      *
      * @param         $to_id
      * @param         $entity
-     * @param         $limit
-     * @param         $paginate
+     * @param  int|null $limit
+     * @param  int|null $paginate
      * @param  string $orderDate
      * @return mixed
      */
-    public function getNotRead($to_id, $entity, $limit = null, $paginate = false, $orderDate = 'desc')
+    public function getNotRead($to_id, $entity, $limit = null, $paginate = null, $orderDate = 'desc')
     {
         $result = $this->notification->with('body', 'from')
             ->wherePolymorphic($to_id, $entity)
@@ -228,6 +228,11 @@ class NotificationRepository implements NotificationDB, StoreNotification
 
         if (! is_null($limit)) {
             $result->limit($limit);
+        }
+
+        if(is_int(intval($paginate)) && !is_null($paginate))
+        {
+            $result->skip(($paginate - 1) * $limit)->take($limit + 1);
         }
 
         return $result->get();
@@ -242,11 +247,11 @@ class NotificationRepository implements NotificationDB, StoreNotification
      * @param         $to_id
      * @param         $entity
      * @param  null   $limit
-     * @param  bool   $paginate
+     * @param  int|null   $paginate
      * @param  string $orderDate
      * @return mixed
      */
-    public function getAll($to_id, $entity, $limit = null, $paginate = false, $orderDate = 'desc')
+    public function getAll($to_id, $entity, $limit = null, $paginate = null, $orderDate = 'desc')
     {
         $result = $this->notification->with('body', 'from')
             ->wherePolymorphic($to_id, $entity)
@@ -256,6 +261,11 @@ class NotificationRepository implements NotificationDB, StoreNotification
         // if the limit is set
         if (! is_null($limit)) {
             $result->limit($limit);
+        }
+
+        if(is_int(intval($paginate)) && !is_null($paginate))
+        {
+            $result->skip(($paginate - 1) * $limit)->take($limit + 1);
         }
 
         return $result->get();


### PR DESCRIPTION
This patch needs to be confirmed, tests are working fine, needs a Laravel full-stacked installation to be completely tested.

### Changes

This patch change two `NotificationRepository` and `NotificationManager` methods :

* `getNotRead($to_id, $limit = null, $paginate = null, $orderDate = 'desc')`
* `getAll($to_id, $limit = null, $paginate = null, $orderDate = 'desc')`

This also change two `getNotificationsNotRead` and `getNotifications` methods :
* `getNotificationsNotRead($limit = null, $paginate = null, $order = 'desc')`
* `getNotifications($limit = null, $paginate = null, $order = 'desc')`

As changed into the PHPDocs Block, `$paginate` parameter is not anymore a boolean, it should be `null` OR `int`, `$paginate` now defines the page you're currently in.

### Examples

```php
// Populate $user with User model instance.
$user = User::find(1);

// Set the limit, it act as the number of notifications that are going to be outputted per page.
$limit = '10';

// Set the current page int
$page = $request->get(‘page’, 1);

// Populate $notificationsNotRead with paginated notifications
$notificationsNotRead = $user->getNotificationsNotRead($limit, $page, $order = 'desc')
$notifications = $user->getNotifications($limit, $page, $order = 'desc')
```