### PR TITLE
Move extracting of extra data out of the foreach

### DIFF
--- a/src/Notifynder/Parsers/NotifynderParser.php
+++ b/src/Notifynder/Parsers/NotifynderParser.php
@@ -107,12 +107,13 @@ class NotifynderParser
     protected function replaceExtraValues($extrasToReplace, $extra, $body)
     {
         // replace the values specified in the extra
+
+        // Whichever type i
+        $extra = $this->extraToArray($extra);
+            
         // wildcard
         foreach ($extrasToReplace as $replacer) {
             $valueMatch = explode('.', $replacer)[1];
-
-            // Whichever type i
-            $extra = $this->extraToArray($extra);
 
             // Let's cover the scenario where the developer
             // forget to add the extra param to a category that it's


### PR DESCRIPTION
I noticed that in my template only the first extra was replaced. After a Debugging Session a found a the following line of code: https://github.com/fenos/Notifynder/blob/master/src/Notifynder/Parsers/NotifynderParser.php#L115

Should this line not be out of the foreach?

If I move this out of the foreach and all works fine.

Reject MR if I'm wrong