### PR TITLE
Use also PHP7 for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:


### PR DESCRIPTION
Also build and test with php7 as the new php version and official supported evrsion of forge and laravel.