### PR TITLE
bugfix

### DIFF
--- a/src/Notifynder/Translator/Compiler.php
+++ b/src/Notifynder/Translator/Compiler.php
@@ -79,7 +79,7 @@ class Compiler
      */
     protected function cachePath()
     {
-        return storage_path('app/notifynder');
+        return 'notifynder';
     }
 
     /**


### PR DESCRIPTION
@Gummibeer  Laravel automatically adds path prefix to it. If you use storage_path, the prefix is added twice. 