### PR TITLE
Fixed `getNotRead()` method pagination ineffective.

### DIFF
--- a/src/Notifynder/Notifications/NotificationManager.php
+++ b/src/Notifynder/Notifications/NotificationManager.php
@@ -173,9 +173,14 @@ class NotificationManager implements NotifynderNotification
      */
     public function getNotRead($toId, $limit = null, $paginate = null, $orderDate = 'desc', Closure $filterScope = null)
     {
+        $queryLimit = $limit;
+        if ($this->isPaginated($paginate)) {
+            $queryLimit = null;
+        }
+
         $notifications = $this->notifynderRepo->getNotRead(
             $toId, $this->entity,
-            $limit, null, $orderDate,
+            $queryLimit, null, $orderDate,
             $filterScope
         );
 


### PR DESCRIPTION
Do similar processing according to the  `getAll()` method.