### PR TITLE
Fix bug where custom fields are not properly merged

### DIFF
--- a/src/Notifynder/Models/Notification.php
+++ b/src/Notifynder/Models/Notification.php
@@ -222,7 +222,7 @@ class Notification extends Model
      */
     protected function mergeFillable()
     {
-        $fillables = array_unique($this->getFillable() + $this->getCustomFillableFields());
+        $fillables = array_unique(array_merge($this->getFillable(), $this->getCustomFillableFields()));
 
         return $fillables;
     }

--- a/src/Notifynder/NotifynderServiceProvider.php
+++ b/src/Notifynder/NotifynderServiceProvider.php
@@ -124,12 +124,6 @@ class NotifynderServiceProvider extends ServiceProvider
             );
         });
 
-        // Inject configs when model is resolved
-        $this->app->resolving(Notification::class, function (Notification $object, $app) {
-            $fillable = $app['config']->get('notifynder.additional_fields.fillable', []);
-            $object->fillable(array_merge($object->getFillable(), $fillable));
-        });
-
         // Default store notification
         $this->app->bind('notifynder.store', 'notifynder.notification.repository');
     }


### PR DESCRIPTION
I was experiencing 2 issues:

1. HTTP requests and console inputs are behaving differently for this particular scenario: custom fields get ignored for http request but are merged fine in the console. I think what happens is: Config is merged in the service provider at model resolution. But then merged again in the model constructor in a __different__ way.  It is also why the test is not catching the bug. The bug currently only exists for http requests (I didn't have time to dig deep enough to explain why but I think the model resolution callback has something to do with it).

2. In the `Notificatoin` model, `getCustomFillableFields()` flattens the additional fields array from the config file which forces it to be a numeric array. And then `mergeFillable()` uses array addition (+) which ignores the custom fields because the numeric keys already exist in the left-hand array.