### PR TITLE
Invalid NotificationCategory constructor

### DIFF
--- a/src/Notifynder/Models/NotificationCategory.php
+++ b/src/Notifynder/Models/NotificationCategory.php
@@ -29,7 +29,7 @@ class NotificationCategory extends Model
      */
     public $timestamps = false;
 
-    public function __construct(array $attributes)
+    public function __construct(array $attributes = [])
     {
         $attributes = array_merge([
             'text' => '',


### PR DESCRIPTION
Not always array is given whe model is being created, therefore we need to add this adjustment.

Error I am seeing:
Type error: Argument 1 passed to Fenos\Notifynder\Models\NotificationCategory::__construct() must be of the type array, none given, called in