### PR TITLE
Add config option for model owner key

### DIFF
--- a/src/Notifynder/Collections/Config.php
+++ b/src/Notifynder/Collections/Config.php
@@ -62,6 +62,14 @@ class Config implements ConfigContract
     }
 
     /**
+     * @return string
+     */
+    public function getNotifiedModelOwnerKey()
+    {
+        return (string) $this->get('model_owner_key', 'id');
+    }
+
+    /**
      * @return array
      */
     public function getAdditionalFields()

--- a/src/Notifynder/Contracts/ConfigContract.php
+++ b/src/Notifynder/Contracts/ConfigContract.php
@@ -28,6 +28,11 @@ interface ConfigContract
     public function getNotifiedModel();
 
     /**
+     * @return string
+     */
+    public function getNotifiedModelOwnerKey();
+
+    /**
      * @return array
      */
     public function getAdditionalFields();

--- a/src/Notifynder/Models/Notification.php
+++ b/src/Notifynder/Models/Notification.php
@@ -91,7 +91,7 @@ class Notification extends Model
             return $this->morphTo('from');
         }
 
-        return $this->belongsTo(notifynder_config()->getNotifiedModel(), 'from_id');
+        return $this->belongsTo(notifynder_config()->getNotifiedModel(), 'from_id', notifynder_config()->getNotifiedModelOwnerKey());
     }
 
     /**
@@ -103,7 +103,7 @@ class Notification extends Model
             return $this->morphTo('to');
         }
 
-        return $this->belongsTo(notifynder_config()->getNotifiedModel(), 'to_id');
+        return $this->belongsTo(notifynder_config()->getNotifiedModel(), 'to_id', notifynder_config()->getNotifiedModelOwnerKey());
     }
 
     /**

--- a/src/config/notifynder.php
+++ b/src/config/notifynder.php
@@ -16,6 +16,13 @@ return [
     'model' => 'App\User',
 
     /*
+     * If your model is not using id as it's primary key
+     * please specific it here, this option is not
+     * considerate if using notifynder as polymorphic
+     */
+    'model_owner_key' => 'id',
+
+    /*
      * Do you want have notifynder that work polymorphically?
      * just swap the value to true and you will able to use it!
      */


### PR DESCRIPTION
Option to set owner key in config for one to many relationship  when  polymorphic is not set to true for cases where user may have different key/table structure for their model.